### PR TITLE
Show possible triggers in EXPLAIN.

### DIFF
--- a/doc/src/sgml/ref/explain.sgml
+++ b/doc/src/sgml/ref/explain.sgml
@@ -43,6 +43,7 @@ EXPLAIN [ ANALYZE ] [ VERBOSE ] <replaceable class="parameter">statement</replac
     BUFFERS [ <replaceable class="parameter">boolean</replaceable> ]
     TIMING [ <replaceable class="parameter">boolean</replaceable> ]
     SUMMARY [ <replaceable class="parameter">boolean</replaceable> ]
+    TRIGGERS [ <replaceable class="parameter">boolean</replaceable> ]
     FORMAT { TEXT | XML | JSON | YAML }
 </synopsis>
  </refsynopsisdiv>
@@ -224,6 +225,14 @@ ROLLBACK;
     </listitem>
    </varlistentry>
 
+   <varlistentry>
+    <term><literal>TRIGGERS</literal></term>
+    <listitem>
+     <para>
+       TODO
+     </para>
+    </listitem>
+   </varlistentry>
    <varlistentry>
     <term><literal>FORMAT</literal></term>
     <listitem>

--- a/src/include/commands/explain.h
+++ b/src/include/commands/explain.h
@@ -35,6 +35,7 @@ typedef struct ExplainState
 	bool		buffers;		/* print buffer usage */
 	bool		timing;			/* print detailed node timing */
 	bool		summary;		/* print total planning and execution timing */
+	bool            triggers;               /* print triggers */
 	bool		settings;		/* print modified settings */
 	ExplainFormat format;		/* output format */
 	/* state for output formatting --- not reset for each new plan tree */

--- a/src/test/regress/expected/foreign_key.out
+++ b/src/test/regress/expected/foreign_key.out
@@ -1421,11 +1421,15 @@ explain (costs off) delete from t1 where a = 1;
                Index Cond: (a = 1)
          ->  Seq Scan on t2
                Filter: (b = 1)
+ Trigger for constraint t2_b_fkey
+ Trigger for constraint t2_b_fkey
  
  Delete on t1
    ->  Index Scan using t1_pkey on t1
          Index Cond: (a = 1)
-(10 rows)
+ Trigger for constraint t2_b_fkey
+ Trigger for constraint t2_b_fkey
+(14 rows)
 
 delete from t1 where a = 1;
 -- Test a primary key with attributes located in later attnum positions

--- a/src/test/regress/expected/insert_conflict.out
+++ b/src/test/regress/expected/insert_conflict.out
@@ -218,7 +218,9 @@ explain (costs off, format json) insert into insertconflicttest values (0, 'Bilb
            "Parallel Aware": false                                     +
          }                                                             +
        ]                                                               +
-     }                                                                 +
+     },                                                                +
+     "Triggers": [                                                     +
+     ]                                                                 +
    }                                                                   +
  ]
 (1 row)

--- a/src/test/regress/expected/updatable_views.out
+++ b/src/test/regress/expected/updatable_views.out
@@ -899,7 +899,10 @@ EXPLAIN (costs off) UPDATE rw_view2 SET a=3 WHERE a=2;
                Recheck Cond: (a > 0)
                ->  Bitmap Index Scan on base_tbl_pkey
                      Index Cond: (a > 0)
-(7 rows)
+ Trigger rw_view1_del_trig
+ Trigger rw_view1_ins_trig
+ Trigger rw_view1_upd_trig
+(10 rows)
 
 EXPLAIN (costs off) DELETE FROM rw_view2 WHERE a=2;
                         QUERY PLAN                        
@@ -911,7 +914,10 @@ EXPLAIN (costs off) DELETE FROM rw_view2 WHERE a=2;
                Recheck Cond: (a > 0)
                ->  Bitmap Index Scan on base_tbl_pkey
                      Index Cond: (a > 0)
-(7 rows)
+ Trigger rw_view1_del_trig
+ Trigger rw_view1_ins_trig
+ Trigger rw_view1_upd_trig
+(10 rows)
 
 DROP TABLE base_tbl CASCADE;
 NOTICE:  drop cascades to 2 other objects


### PR DESCRIPTION
# motivation

Recently I got few times into situation where I was trying to find out what is blocking DELETE queries. Running `EXPLAIN` (even `VERBOSE` one) wasn't useful, since the reason was slow trigger (missing index on foreign key column). I had to create testing entry and run `EXPLAIN ANALYZE DELETE` to get this information.

It will be really valuable for me to show triggers in `EXPLAIN` query since it will make clear for me there will be any trigger "activated" during execution of `DELETE` query and that can be the reason for slow `DELETE`. I have added EXPLAIN option called `TRIGGERS` enabled by default. There's already autoexplain property for this.

I understand it is not possible to show only triggers which will be really activated unless query is really executed. `EXPLAIN ANALYZE` remains untouched with this patch. 

I have seen initial discussion at https://www.postgresql.org/message-id/flat/20693.1111732761%40sss.pgh.pa.us to show time spent in triggers in `EXPLAIN ANALYZE` including quick discussion to possibly show triggers during `EXPLAIN`. Anyway since it doesn't show any additional cost and just inform about the possibilities, I still consider this feature useful. This is probably implementation of idea mentioned at https://www.postgresql.org/message-id/21221.1111736869%40sss.pgh.pa.us by Tom Lane:

```
We might as well just add one line saying
	<ding> You've got triggers!
```

:green_heart: All regression tests passed with this change locally.

## before:

```sql
psql reporting_development -c "explain delete from sales_distribution_channels where id=9;"
                                                        QUERY PLAN                                                        
--------------------------------------------------------------------------------------------------------------------------
 Delete on sales_distribution_channels  (cost=0.14..8.16 rows=1 width=6)
   ->  Index Scan using sales_distribution_channels_pkey on sales_distribution_channels  (cost=0.14..8.16 rows=1 width=6)
         Index Cond: (id = 9)
(3 rows)

psql reporting_development -c "explain verbose delete from sales_distribution_channels where id=9;"
                                                           QUERY PLAN                                                            
---------------------------------------------------------------------------------------------------------------------------------
 Delete on public.sales_distribution_channels  (cost=0.14..8.16 rows=1 width=6)
   ->  Index Scan using sales_distribution_channels_pkey on public.sales_distribution_channels  (cost=0.14..8.16 rows=1 width=6)
         Output: ctid
         Index Cond: (sales_distribution_channels.id = 9)
(4 rows)
```

## after

```sql
psql reporting_development -c "explain delete from sales_distribution_channels where id=9;"
                                                        QUERY PLAN                                                        
--------------------------------------------------------------------------------------------------------------------------
 Delete on sales_distribution_channels  (cost=0.14..8.16 rows=1 width=6)
   ->  Index Scan using sales_distribution_channels_pkey on sales_distribution_channels  (cost=0.14..8.16 rows=1 width=6)
         Index Cond: (id = 9)
 Trigger for constraint sales_sales_distribution_channel_id_fk
 Trigger for constraint sales_sales_distribution_channel_id_fk
 Trigger for constraint sales_distribution_channels_account_id_fk
 Trigger for constraint sales_distribution_channels_account_id_fk
(7 rows)

psql reporting_development -c "explain verbose delete from sales_distribution_channels where id=9;"
                                                           QUERY PLAN                                                            
---------------------------------------------------------------------------------------------------------------------------------
 Delete on public.sales_distribution_channels  (cost=0.14..8.16 rows=1 width=6)
   ->  Index Scan using sales_distribution_channels_pkey on public.sales_distribution_channels  (cost=0.14..8.16 rows=1 width=6)
         Output: ctid
         Index Cond: (sales_distribution_channels.id = 9)
 Trigger RI_ConstraintTrigger_a_45806 for constraint sales_sales_distribution_channel_id_fk
 Trigger RI_ConstraintTrigger_a_45807 for constraint sales_sales_distribution_channel_id_fk
 Trigger RI_ConstraintTrigger_c_45698 for constraint sales_distribution_channels_account_id_fk
 Trigger RI_ConstraintTrigger_c_45699 for constraint sales_distribution_channels_account_id_fk
(8 rows)
```